### PR TITLE
Properly support chunks containing a single line

### DIFF
--- a/diffparser.go
+++ b/diffparser.go
@@ -154,28 +154,45 @@ func Parse(diffString string) (*Diff, error) {
 			file.Hunks = append(file.Hunks, hunk)
 			hunkLineCount = 0
 			// Parse hunk heading for ranges
-			re := regexp.MustCompile(`@@ \-(\d+),(\d+) \+(\d+),?(\d+)? @@`)
+			re := regexp.MustCompile(`@@ \-(\d+),?(\d+)? \+(\d+),?(\d+)? @@`)
+			re_all := regexp.MustCompile(`@@ \-(\d+),(\d+) \+(\d+),(\d+) @@`)
+			re_end := regexp.MustCompile(`@@ \-(\d+) \+(\d+),(\d+) @@`)
+			re_begin := regexp.MustCompile(`@@ \-(\d+),(\d+) \+(\d+) @@`)
 			m := re.FindStringSubmatch(l)
+			match_all := re_all.MatchString(l)
+			match_end := re_end.MatchString(l)
+			match_begin := re_begin.MatchString(l)
 			a, err := strconv.Atoi(m[1])
 			if err != nil {
 				return nil, err
 			}
-			b, err := strconv.Atoi(m[2])
-			if err != nil {
-				return nil, err
-			}
-			c, err := strconv.Atoi(m[3])
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
+			b := a
+			c := b
 			d := c
+			if len(m[2]) > 0 {
+				b, err = strconv.Atoi(m[2])
+				if err != nil {
+					return nil, err
+				}
+			}
+			if len(m[3]) > 0 {
+				c, err = strconv.Atoi(m[3])
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+			}
 			if len(m[4]) > 0 {
 				d, err = strconv.Atoi(m[4])
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
 			}
-
+			if !(match_all || match_begin) {
+				b = 1
+			}
+			if !(match_all || match_end) {
+				d = 1
+			}
 			// hunk orig range.
 			hunk.OrigRange = diffRange{
 				Start:  a,


### PR DESCRIPTION
When working on chunks containing 1 line either as the original or the new chunk, the parser would fail on a strconv. This properly avoids attempting to convert empty strings and sets the lengths correctly.

Example failure input:

``` diff
diff --git a/foo.txt b/foo.txt
index 9daeafb..2bdc76e 100644
--- a/foo.txt
+++ b/foo.txt
@@ -1 +1,2 @@
 test
+bar
```
