### PR TITLE
Handle diffs containing deleted symlinks (fixes a go panic)

### DIFF
--- a/diffparser.go
+++ b/diffparser.go
@@ -4,6 +4,7 @@
 package diffparser
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -164,6 +165,9 @@ func Parse(diffString string) (*Diff, error) {
 			// Parse hunk heading for ranges
 			re := regexp.MustCompile(`@@ \-(\d+),?(\d+)? \+(\d+),?(\d+)? @@`)
 			m := re.FindStringSubmatch(l)
+			if len(m) < 5 {
+				return nil, errors.Trace(fmt.Errorf("Error parsing line: %s", l))
+			}
 			a, err := strconv.Atoi(m[1])
 			if err != nil {
 				return nil, err

--- a/diffparser.go
+++ b/diffparser.go
@@ -162,15 +162,18 @@ func Parse(diffString string) (*Diff, error) {
 			file.Hunks = append(file.Hunks, hunk)
 
 			// Parse hunk heading for ranges
-			re := regexp.MustCompile(`@@ \-(\d+),(\d+) \+(\d+),?(\d+)? @@`)
+			re := regexp.MustCompile(`@@ \-(\d+),?(\d+)? \+(\d+),?(\d+)? @@`)
 			m := re.FindStringSubmatch(l)
 			a, err := strconv.Atoi(m[1])
 			if err != nil {
 				return nil, err
 			}
-			b, err := strconv.Atoi(m[2])
-			if err != nil {
-				return nil, err
+			b := a
+			if len(m[2]) > 0 {
+				b, err = strconv.Atoi(m[2])
+				if err != nil {
+					return nil, err
+				}
 			}
 			c, err := strconv.Atoi(m[3])
 			if err != nil {

--- a/diffparser_test.go
+++ b/diffparser_test.go
@@ -37,7 +37,7 @@ func (s *suite) SetUpSuite(c *gc.C) {
 func (s *suite) TestFileModeAndNaming(c *gc.C) {
 	diff, err := diffparser.Parse(s.rawdiff)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(diff.Files, gc.HasLen, 5)
+	c.Assert(diff.Files, gc.HasLen, 6)
 
 	for i, expected := range []struct {
 		mode     diffparser.FileMode
@@ -69,6 +69,11 @@ func (s *suite) TestFileModeAndNaming(c *gc.C) {
 			origName: "",
 			newName:  "newname",
 		},
+		{
+			mode:     diffparser.DELETED,
+			origName: "symlink",
+			newName:  "",
+		},
 	} {
 		file := diff.Files[i]
 		c.Logf("testing file: %v", file)
@@ -81,7 +86,7 @@ func (s *suite) TestFileModeAndNaming(c *gc.C) {
 func (s *suite) TestHunk(c *gc.C) {
 	diff, err := diffparser.Parse(s.rawdiff)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(diff.Files, gc.HasLen, 5)
+	c.Assert(diff.Files, gc.HasLen, 6)
 
 	expectedOrigLines := []diffparser.DiffLine{
 		{

--- a/example.diff
+++ b/example.diff
@@ -47,3 +47,11 @@ index 0000000..c0dafd8
 +lines
 +in
 +file2
+diff --git a/symlink b/symlink
+deleted file mode 120000
+index 03b9162..0000000
+--- a/symlink
++++ /dev/null
+@@ -1 +0,0 @@
+-symlink-destination
+\ No newline at end of file


### PR DESCRIPTION
Previously, this regex didn't match diffs for deleted symlinks: https://github.com/waigani/diffparser/blob/master/diffparser.go#L165

This led to a panic here: https://github.com/waigani/diffparser/blob/master/diffparser.go#L167

If the Regex finds no matches, the code tried to index into an array of length 0.