### PR TITLE
Make diffRange public

### DIFF
--- a/diffparser.go
+++ b/diffparser.go
@@ -23,7 +23,7 @@ const (
 	NEW
 )
 
-type diffRange struct {
+type DiffRange struct {
 
 	// starting line number
 	Start int
@@ -58,9 +58,9 @@ type DiffLine struct {
 // DiffHunk is a group of difflines
 type DiffHunk struct {
 	HunkHeader string
-	OrigRange  diffRange
-	NewRange   diffRange
-	WholeRange diffRange
+	OrigRange  DiffRange
+	NewRange   DiffRange
+	WholeRange DiffRange
 }
 
 // DiffFile is the sum of diffhunks and holds the changes of the file features
@@ -224,13 +224,13 @@ func Parse(diffString string) (*Diff, error) {
 			}
 
 			// hunk orig range.
-			hunk.OrigRange = diffRange{
+			hunk.OrigRange = DiffRange{
 				Start:  a,
 				Length: b,
 			}
 
 			// hunk new range.
-			hunk.NewRange = diffRange{
+			hunk.NewRange = DiffRange{
 				Start:  c,
 				Length: d,
 			}


### PR DESCRIPTION
Hi, I'm lover of this parser. In particular, keeping the mode of each line helps me a lot.

in order to make a mock of `diffparser.Diff` in a test case, `diffRange` have to be made yourself.
So if there's no particular reason, I guess `diffRange` should be public.
