### PR TITLE
Fixed panic on diffparser when first line is invalid

### DIFF
--- a/diffparser.go
+++ b/diffparser.go
@@ -134,6 +134,13 @@ func Parse(diffString string) (*Diff, error) {
 	diff.Raw = diffString
 	lines := strings.Split(diffString, "\n")
 
+	if !strings.HasPrefix(diffString, "diff ") {
+		return nil, errors.New("Invalid diffString prefix")
+	}
+	if len(lines) < 3 {
+		return nil, errors.New("Invalid diffString. Lines count is too short")
+	}
+
 	var file *DiffFile
 	var hunk *DiffHunk
 	var ADDEDCount int
@@ -275,6 +282,8 @@ func Parse(diffString string) (*Diff, error) {
 				ADDEDCount++
 				REMOVEDCount++
 			}
+		default:
+			continue
 		}
 	}
 


### PR DESCRIPTION
There is a panic that is not caught on the latest release of diffparser that is not caught by `error` handling. 


I have introduced in my tool, and thought to share the fix with everyone, and hopefully to have it merged soon.

How to produce the panic?

The `diff_raw` is missing `diff --git a/file.txt b/file.txt`
```
	var diff_raw string = `
new file mode 100644
index 0000000..814b5ab
--- /dev/null
+++ b/file.txt
@@ -0,0 +1,4 @@
+Hello world`

diff, err := diffparser.Parse(diff_raw)
if err != nill {
  error.Wrapf("handled successfully", err)
}
```

Best Regards,
Mazin