### PR TITLE
Fix parse rename use-case

### DIFF
--- a/diffparser.go
+++ b/diffparser.go
@@ -139,8 +139,10 @@ func Parse(diffString string) (*Diff, error) {
 	var ADDEDCount int
 	var REMOVEDCount int
 	var inHunk bool
-	oldFilePrefix := "--- a/"
-	newFilePrefix := "+++ b/"
+	oldFilePrefix1 := "--- a/"
+	oldFilePrefix2 := "rename from "
+	newFilePrefix1 := "+++ b/"
+	newFilePrefix2 := "rename to "
 
 	var diffPosCount int
 	var firstHunkInFile bool
@@ -177,10 +179,14 @@ func Parse(diffString string) (*Diff, error) {
 			file.Mode = DELETED
 		case l == "--- /dev/null":
 			file.Mode = NEW
-		case strings.HasPrefix(l, oldFilePrefix):
-			file.OrigName = strings.TrimPrefix(l, oldFilePrefix)
-		case strings.HasPrefix(l, newFilePrefix):
-			file.NewName = strings.TrimPrefix(l, newFilePrefix)
+		case strings.HasPrefix(l, oldFilePrefix1):
+			file.OrigName = strings.TrimPrefix(l, oldFilePrefix1)
+		case strings.HasPrefix(l, newFilePrefix1):
+			file.NewName = strings.TrimPrefix(l, newFilePrefix1)
+		case strings.HasPrefix(l, oldFilePrefix2):
+			file.OrigName = strings.TrimPrefix(l, oldFilePrefix2)
+		case strings.HasPrefix(l, newFilePrefix2):
+			file.NewName = strings.TrimPrefix(l, newFilePrefix2)
 		case strings.HasPrefix(l, "@@ "):
 			if firstHunkInFile {
 				diffPosCount = 0

--- a/diffparser_test.go
+++ b/diffparser_test.go
@@ -19,7 +19,7 @@ func setup(t *testing.T) *Diff {
 
 	diff, err := Parse(string(byt))
 	require.NoError(t, err)
-	require.Equal(t, len(diff.Files), 6)
+	require.Equal(t, len(diff.Files), 7)
 
 	return diff
 }
@@ -59,6 +59,11 @@ func TestFileModeAndNaming(t *testing.T) {
 			mode:     DELETED,
 			origName: "symlink",
 			newName:  "",
+		},
+		{
+			mode:     MODIFIED,
+			origName: "example",
+			newName:  "example1",
 		},
 	} {
 		file := diff.Files[i]

--- a/example.diff
+++ b/example.diff
@@ -55,3 +55,7 @@ index 03b9162..0000000
 @@ -1 +0,0 @@
 -symlink-destination
 \ No newline at end of file
+diff --git a/example b/example1
+similarity index 100%
+rename from example
+rename to example1


### PR DESCRIPTION
Fix the parser when parsing renamed files which have no changes this can be observed using `git mv ` then `git diff`