### PR TITLE
Translate original line number to current file and vice-versa

### DIFF
--- a/diffparser_test.go
+++ b/diffparser_test.go
@@ -135,3 +135,49 @@ func TestHunk(t *testing.T) {
 		require.Equal(t, line, *newRange.Lines[i])
 	}
 }
+
+func TestNewToOriginalFile(t *testing.T) {
+	diff := setup(t)
+	expectedOrigLines := []struct {
+		LineNumber int
+		Expected   int
+	}{
+		{
+			LineNumber: 2,
+			Expected:   1,
+		},
+		{
+			LineNumber: 3,
+			Expected:   2,
+		},
+	}
+
+	for _, line := range expectedOrigLines {
+		actual, err := diff.TranslateNewToOriginal("file1", line.LineNumber)
+		require.NoError(t, err)
+		require.Equal(t, line.Expected, actual)
+	}
+}
+
+func TestOriginalToNew(t *testing.T) {
+	diff := setup(t)
+	expectedOrigLines := []struct {
+		LineNumber int
+		Expected   int
+	}{
+		{
+			LineNumber: 1,
+			Expected:   2,
+		},
+		{
+			LineNumber: 2,
+			Expected:   3,
+		},
+	}
+
+	for _, line := range expectedOrigLines {
+		actual, err := diff.TranslateOriginalToNew("file1", line.LineNumber)
+		require.NoError(t, err)
+		require.Equal(t, line.Expected, actual)
+	}
+}


### PR DESCRIPTION
I am currently working on a differential test coverage analysis tool. It requires having the diff of the changes to detect which lines of code's coverage have changed and keeping track of line numbers between two source file versions.

This pull requests adds a feature to support my use-case.

To explain my test, take the following diff:

```diff
diff --git a/file1 b/file1
index 504d2a1..50ccec3 100644
--- a/file1
+++ b/file1
@@ -1,4 +1,4 @@
+add a line
 some
 lines
-in
 file1
```

The 1st line in the original was "some", but is translated to the 2nd line in the new version because of the new line "add a line".